### PR TITLE
fixed import problen with newer openpyxl versions

### DIFF
--- a/admin_export_action/report.py
+++ b/admin_export_action/report.py
@@ -24,7 +24,6 @@ from django.utils import timezone
 from openpyxl.styles import Font
 from openpyxl.utils import get_column_letter
 from openpyxl.workbook import Workbook
-from openpyxl.writer.excel import save_virtual_workbook
 
 from six import BytesIO, text_type
 
@@ -225,7 +224,7 @@ def build_xlsx_response(wb, title="report"):
     """ Take a workbook and return a xlsx file response """
     title = generate_filename(title, '.xlsx')
     myfile = BytesIO()
-    myfile.write(save_virtual_workbook(wb))
+    wb.save(myfile)
     response = HttpResponse(
         myfile.getvalue(),
         content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')

--- a/testapp/app/requirements.txt
+++ b/testapp/app/requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.5.2
 cachetools==4.1.1
 certifi==2020.12.5
 chardet==3.0.4
-codecov==2.1.12
+codecov==2.1.13
 coverage==5.3
 Django==4.1.1
 django-baton==2.4.1


### PR DESCRIPTION
Fixed problem with function save_virtual_workbook from openpyxl not being available anymore in openpyxl=3.1.2 (or even earlier versions).

See issue 7 (https://github.com/otto-torino/django-admin-export-action/issues/7)